### PR TITLE
Change chunk string concatenation

### DIFF
--- a/src/split_in_chunks_dialog.py
+++ b/src/split_in_chunks_dialog.py
@@ -240,7 +240,7 @@ class SplitDlg(QtWidgets.QDialog):
                     new_chunk = chunk.copy(items=[PhotoScan.DataSource.DenseCloudData, PhotoScan.DataSource.DepthMapsData])
                 else:
                     new_chunk = chunk.copy(items=[])
-                new_chunk.label = "Chunk " + str(i) + "\\" + str(j)
+                new_chunk.label = "Chunk " + str(i) + "_" + str(j)
                 if new_chunk.model:
                     new_chunk.model.clear()
 


### PR DESCRIPTION
The use of \\ in the chunk label is blocking the use of {chunklabel} on Windows as this character isn't allowed in a filename