### PR TITLE
Use list of int for chunks parameter in doc.mergeChunks()

### DIFF
--- a/src/split_in_chunks_dialog.py
+++ b/src/split_in_chunks_dialog.py
@@ -334,7 +334,7 @@ class SplitDlg(QtWidgets.QDialog):
             for chunk in temporary_chunks:
                 chunk.remove(chunk.cameras)
             original_chunk.model = None  # hiding the mesh of the original chunk, just for case
-            doc.mergeChunks([original_chunk] + temporary_chunks,
+        doc.mergeChunks(chunks = [original_chunk.key] + [chunk.key for chunk in temporary_chunks],
                             merge_dense_clouds=True, merge_models=True, merge_markers=True)  # merging all smaller chunks into single one
             merged_chunk = doc.chunks[-1]
             merged_chunk.region = original_region

--- a/src/split_in_chunks_dialog.py
+++ b/src/split_in_chunks_dialog.py
@@ -334,7 +334,7 @@ class SplitDlg(QtWidgets.QDialog):
             for chunk in temporary_chunks:
                 chunk.remove(chunk.cameras)
             original_chunk.model = None  # hiding the mesh of the original chunk, just for case
-        doc.mergeChunks(chunks = [original_chunk.key] + [chunk.key for chunk in temporary_chunks],
+            doc.mergeChunks(chunks = [original_chunk.key] + [chunk.key for chunk in temporary_chunks],
                             merge_dense_clouds=True, merge_models=True, merge_markers=True)  # merging all smaller chunks into single one
             merged_chunk = doc.chunks[-1]
             merged_chunk.region = original_region


### PR DESCRIPTION
Hello,

I am noticing an error in merge part of split_in_chunks_dialog script.

I am using the script on 2nd chunk (Copy of Merged Chunk) of a project to split into 2 chunks, generate dense cloud and then merge back. But when merging it actually meges all the chunks including 1st chunk as seen in number of images in resulting Merged Chunk (486 instead of 243)... see attachment...

the merge operation corresponds to following line from script:

Code: [Select]
doc.mergeChunks([original_chunk] + temporary_chunks,
                            merge_dense_clouds=True, merge_models=True, merge_markers=True)  # merging all smaller chunks into single one

where we have a list of chunks to merge ([original_chunk] + temporary_chunks)...

however the API documentation specifies a list of integer for chunks:
Quote
mergeChunks(merge_markers=False, merge_tiepoints=False, merge_depth_maps=False,
merge_dense_clouds=True, merge_models=False, merge_elevations=False,
merge_orthomosaics=False[, chunks ][, progress ])
Merge specified set of chunks.
Parameters
• merge_markers (bool) – Merge markers.
• merge_tiepoints (bool) – Merge tie points.
• merge_depth_maps (bool) – Merge depth maps.
• merge_dense_clouds (bool) – Merge dense clouds.
• merge_models (bool) – Merge models.
• merge_elevations (bool) – Merge DEMs.
• merge_orthomosaics (bool) – Merge orthomosaics.
• chunks (list of int) – List of chunks to process.
• progress (Callable[[float], None]) – Progress callback

Shouldn`t the script use chunk.key instead of chunk when building list of chunks? and use following line for merge operation:
Code: [Select]
doc.mergeChunks(chunks = [original_chunk.key] + [chunk.key for chunk in temporary_chunks],
                            merge_dense_clouds=True, merge_models=True, merge_markers=True)  # merging all smaller chunks into single one