### PR TITLE
Update save_estimated_reference.py

### DIFF
--- a/src/save_estimated_reference.py
+++ b/src/save_estimated_reference.py
@@ -70,7 +70,7 @@ class CameraStats():
             self.sigma_location = Metashape.Vector([math.sqrt(cov[0, 0]), math.sqrt(cov[1, 1]), math.sqrt(cov[2, 2])])
 
         if camera.rotation_covariance:
-            T = crs.localframe(location_ecef) * camera_transform
+            T = localframe * camera_transform  # to reflect rotation angles ypr (ecef_crs.localfram) or opk (crs.localframe)
             R0 = T.rotation()
 
             dR = antenna_transform.rotation()


### PR DESCRIPTION
In case of camera rotation covariance should use localframe according to ypr (ecef_crs.localframe) or opk (crs.localframe) to reflect different angle references.......
By the way could you explain the math behind the use of dmat2euler utility?