### PR TITLE
Image_quality.py

### DIFF
--- a/misc/links.txt
+++ b/misc/links.txt
@@ -1,0 +1,4 @@
+https://download.lfd.uci.edu/pythonlibs/archived/GDAL-3.4.3-cp39-cp39-win_amd64.whl
+https://download.lfd.uci.edu/pythonlibs/archived/Fiona-1.8.21-cp39-cp39-win_amd64.whl
+https://download.lfd.uci.edu/pythonlibs/archived/rasterio-1.2.10-cp39-cp39-win_amd64.whl
+https://download.lfd.uci.edu/pythonlibs/archived/pyhull-2015.2.1-cp39-cp39-win_amd64.whl

--- a/src/add_altitude_to_reference.py
+++ b/src/add_altitude_to_reference.py
@@ -5,7 +5,7 @@
 import Metashape
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/align_model_to_model.py
+++ b/src/align_model_to_model.py
@@ -26,7 +26,7 @@ found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))
 
-import urllib, tempfile
+import urllib.request, tempfile
 temporary_file = tempfile.NamedTemporaryFile(delete=False)
 find_links_file_url = "https://raw.githubusercontent.com/agisoft-llc/metashape-scripts/master/misc/links.txt"
 urllib.request.urlretrieve(find_links_file_url, temporary_file.name)

--- a/src/align_model_to_model.py
+++ b/src/align_model_to_model.py
@@ -26,9 +26,14 @@ found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))
 
-pip_install("""-f https://raw.githubusercontent.com/agisoft-llc/metashape-scripts/master/misc/links.txt
+import urllib, tempfile
+temporary_file = tempfile.NamedTemporaryFile(delete=False)
+find_links_file_url = "https://raw.githubusercontent.com/agisoft-llc/metashape-scripts/master/misc/links.txt"
+urllib.request.urlretrieve(find_links_file_url, temporary_file.name)
+
+pip_install("""-f {find_links_file_path}
 open3d == 0.16.0
-pyhull == 2015.2.1""");
+pyhull == 2015.2.1""".format(find_links_file_path=temporary_file.name.replace("\\", "\\\\")))
 
 import open3d as o3d
 from pyhull.convex_hull import ConvexHull

--- a/src/automatic_masking.py
+++ b/src/automatic_masking.py
@@ -30,7 +30,7 @@ found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))
 
-pip_install('''rembg==2.0.24''')
+pip_install('''rembg==2.0.*''')
 
 def generate_automatic_background_masks_with_rembg(chunk=None):
     try:
@@ -61,7 +61,7 @@ def generate_automatic_background_masks_with_rembg(chunk=None):
     masks_dirs_created = set()
     cameras_by_masks_dir = {}
     for i, c in enumerate(cameras):
-        if not camera.type == Metashape.Camera.Type.Regular: #skip camera track, if any
+        if not c.type == Metashape.Camera.Type.Regular: #skip camera track, if any
             continue
 
         input_image_path = c.photo.path

--- a/src/automatic_masking.py
+++ b/src/automatic_masking.py
@@ -127,8 +127,8 @@ def generate_automatic_background_masks_with_rembg(chunk=None):
         mask = np.array(mask)
 
         mask = (mask > 10)
-        mask = scipy.ndimage.morphology.binary_dilation(mask, iterations=3)
-        mask = scipy.ndimage.morphology.binary_erosion(mask, iterations=3)
+        mask = scipy.ndimage.binary_dilation(mask, iterations=3)
+        mask = scipy.ndimage.binary_erosion(mask, iterations=3)
         mask = mask.astype(np.uint8) * 255
         mask = np.dstack([mask, mask, mask])
 

--- a/src/bounding_box_to_coordinate_system.py
+++ b/src/bounding_box_to_coordinate_system.py
@@ -6,7 +6,7 @@ import Metashape
 import math
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/colorize_model_by_altitude.py
+++ b/src/colorize_model_by_altitude.py
@@ -7,7 +7,7 @@
 import Metashape
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/colorize_model_by_overlap.py
+++ b/src/colorize_model_by_overlap.py
@@ -9,7 +9,7 @@ import Metashape
 import time
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/contrib/apply_offset_to_cameras.py
+++ b/src/contrib/apply_offset_to_cameras.py
@@ -22,7 +22,7 @@ import Metashape
 print("Script started...")
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(

--- a/src/contrib/change_chunk_names.py
+++ b/src/contrib/change_chunk_names.py
@@ -12,7 +12,7 @@ ex) image name: "M33333_human_CR_000" -> chunk name: "M33333_human_CR"
 
 """
 
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/contrib/disable_models.py
+++ b/src/contrib/disable_models.py
@@ -10,7 +10,7 @@ This scrip disable current model of chunks.
 It is useful when you want to make models different quality in one batch process.
 """
 
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/contrib/gradual_selection_mesh.py
+++ b/src/contrib/gradual_selection_mesh.py
@@ -11,7 +11,7 @@ This script scans the number of components in a model and reduceing them continu
 I wanted to make "grasdual selection" tool, but this is slower than that.
 """
 
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/contrib/gradual_selection_tie_points.py
+++ b/src/contrib/gradual_selection_tie_points.py
@@ -6,10 +6,10 @@ Metashape Sparse Point Cloud Filter Script (v 1.7)
 Matjaz Mori, CPA, June 2019
 Usage:
 Workflow -> Batch Process -> Add -> Run script
-In the row "Argumets" we enter exactly 4 values ​​without spaces for: ReprojectionError, ReconstructionUncertainty, ImageCount, ProjectionAccuracy in this order.
+In the row "Argumets" we enter exactly 4 values without spaces for: ReprojectionError, ReconstructionUncertainty, ImageCount, ProjectionAccuracy in this order.
 ex: 1 15 3 5
 or
-leave the "Arguments" line blank, in which case the default values ​​will be used,
+leave the "Arguments" line blank, in which case the default values will be used,
 which can also be modified in the script itself under the variables def_reperr, def_recunc, def_imgcount and def_projacc.
 When using, it is advisable to monitor the Console (View -> Console).
 """
@@ -28,23 +28,23 @@ projacc = float(sys.argv[4] if paramNo == 5 else def_projacc)
 
 
 for chunk in Metashape.app.document.chunks:
-    f = Metashape.PointCloud.Filter()
-    f.init(chunk, Metashape.PointCloud.Filter.ReprojectionError)
+    f = Metashape.TiePoints.Filter()
+    f.init(chunk, Metashape.TiePoints.Filter.ReprojectionError)
     f.removePoints(reperr)
 
 for chunk in Metashape.app.document.chunks:
-    f = Metashape.PointCloud.Filter()
-    f.init(chunk, Metashape.PointCloud.Filter.ReconstructionUncertainty)
+    f = Metashape.TiePoints.Filter()
+    f.init(chunk, Metashape.TiePoints.Filter.ReconstructionUncertainty)
     f.removePoints(recunc)
 
 for chunk in Metashape.app.document.chunks:
-    f = Metashape.PointCloud.Filter()
-    f.init(chunk, Metashape.PointCloud.Filter.ImageCount)
+    f = Metashape.TiePoints.Filter()
+    f.init(chunk, Metashape.TiePoints.Filter.ImageCount)
     f.removePoints(imgcount)
 
 for chunk in Metashape.app.document.chunks:
-    f = Metashape.PointCloud.Filter()
-    f.init(chunk, Metashape.PointCloud.Filter.ProjectionAccuracy)
+    f = Metashape.TiePoints.Filter()
+    f.init(chunk, Metashape.TiePoints.Filter.ProjectionAccuracy)
     f.removePoints(projacc)
 
 if paramNo == 5:

--- a/src/contrib/remove_disabled_photos.py
+++ b/src/contrib/remove_disabled_photos.py
@@ -15,7 +15,7 @@ When using, it is advisable to monitor the Console (View -> Console).
 
 """
 
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))
@@ -37,6 +37,9 @@ def remove_disabled_photos():
     print (message)
 
     for camera in chunk.cameras:
+        if not camera.type == Metashape.Camera.Type.Regular: #skip camera track, if any
+            continue
+
         if camera.enabled is True:
             counter_not_moved = counter_not_moved + 1
             continue # skipping enabled cameras

--- a/src/contrib/remove_duplicated_photos.py
+++ b/src/contrib/remove_duplicated_photos.py
@@ -8,7 +8,7 @@ Matjaz Mori, CPA, May 2022
 The script will remove all duplicated photos (photos referenced to the same file) from Metashape project. 
 """
 
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))
@@ -27,6 +27,9 @@ def remove_duplicated_photos():
     paths = set()
     photos = list()
     for camera in list(chunk.cameras):
+        if not camera.type == Metashape.Camera.Type.Regular: #skip camera track, if any
+            continue
+
         if camera.photo.path in paths:
             photos.append(camera)
         else:

--- a/src/contrib/save_chunks.py
+++ b/src/contrib/save_chunks.py
@@ -10,7 +10,7 @@ This script saves each chunks separately.
 
 """
 
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/coordinate_system_to_bounding_box.py
+++ b/src/coordinate_system_to_bounding_box.py
@@ -6,7 +6,7 @@ import Metashape
 import math
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/copy_bounding_box_dialog.py
+++ b/src/copy_bounding_box_dialog.py
@@ -6,7 +6,7 @@ import Metashape
 from PySide2 import QtGui, QtCore, QtWidgets
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -12,29 +12,15 @@
 #
 # How to install (Linux):
 #
-# 1. cd .../metashape-pro
-#    LD_LIBRARY_PATH=`pwd`/python/lib/ python/bin/python3.8 -m pip install albumentations==1.0.3 deepforest pytorch-lightning==1.5.10 torch==1.9.0+cu111 torchvision==0.10.0+cu111 torchaudio==0.9.0 -f https://download.pytorch.org/whl/torch_stable.html
-# 2. Add this script to auto-launch - https://agisoft.freshdesk.com/support/solutions/articles/31000133123-how-to-run-python-script-automatically-on-metashape-professional-start
+# 1. Add this script to auto-launch - https://agisoft.freshdesk.com/support/solutions/articles/31000133123-how-to-run-python-script-automatically-on-metashape-professional-start
 #    copy detect_objects.py script to /home/<username>/.local/share/Agisoft/Metashape Pro/scripts/
+# 2. Restart Metashape.
 #
 # How to install (Windows):
 #
-# 1. Download latest gdal, rasterio and fiona packages (for Python 3.8 amd64, i.e. download files ending with ...cp38‑cp38‑win_amd64.whl)
-#    gdal     - https://www.lfd.uci.edu/~gohlke/pythonlibs/#gdal
-#    rasterio - https://www.lfd.uci.edu/~gohlke/pythonlibs/#rasterio
-#    fiona    - https://www.lfd.uci.edu/~gohlke/pythonlibs/#fiona
-# 2. Now you need to install these downloaded python packages wheel:
-# 3. Launch cmd.exe with the administrator privileges
-# 4. Change directory to Downloads directory (where three downloaded files are located):
-#   cd %USERPROFILE%/Downloads
-# 5. Install them one by one:
-#    "%programfiles%\Agisoft\Metashape Pro\python\python.exe" -m pip install GDAL‑3.4.2‑cp38‑cp38‑win_amd64.whl
-#    "%programfiles%\Agisoft\Metashape Pro\python\python.exe" -m pip install rasterio‑1.2.10‑cp38‑cp38‑win_amd64.whl
-#    "%programfiles%\Agisoft\Metashape Pro\python\python.exe" -m pip install Fiona‑1.8.21‑cp38‑cp38‑win_amd64.whl
-# 6. Install pytorch with CUDA support and deepforest:
-#    "%programfiles%\Agisoft\Metashape Pro\python\python.exe" -m pip install albumentations==1.0.3 deepforest pytorch-lightning==1.5.10 torch==1.9.0+cu111 torchvision==0.10.0+cu111 torchaudio===0.9.0 -f https://download.pytorch.org/whl/torch_stable.html
-# 7. Add this script to auto-launch - https://agisoft.freshdesk.com/support/solutions/articles/31000133123-how-to-run-python-script-automatically-on-metashape-professional-start
+# 1. Add this script to auto-launch - https://agisoft.freshdesk.com/support/solutions/articles/31000133123-how-to-run-python-script-automatically-on-metashape-professional-start
 #    copy detect_objects.py script to C:/Users/<username>/AppData/Local/Agisoft/Metashape Pro/scripts/
+# 2. Restart Metashape
 #
 # How to use:
 #
@@ -77,14 +63,23 @@
 import Metashape
 import pathlib, shutil, os, time
 from PySide2 import QtGui, QtCore, QtWidgets
+from modules.pip_auto_install import pip_install
 
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))
 
+pip_install("""-f https://download.pytorch.org/whl/torch_stable.html
+-f https://raw.githubusercontent.com/agisoft-llc/metashape-scripts/master/misc/links.txt
+albumentations==1.0.3
+deepforest==1.2.4
+pytorch-lightning==1.5.10
+torch==1.9.0+cu111
+torchvision==0.10.0+cu111
+torchaudio===0.9.0""")
 
 def pandas_append(df, row, ignore_index=False):
     import pandas as pd

--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -72,7 +72,7 @@ found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))
 
-import urllib, tempfile
+import urllib.request, tempfile
 temporary_file = tempfile.NamedTemporaryFile(delete=False)
 find_links_file_url = "https://raw.githubusercontent.com/agisoft-llc/metashape-scripts/master/misc/links.txt"
 urllib.request.urlretrieve(find_links_file_url, temporary_file.name)

--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -72,14 +72,19 @@ found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))
 
-pip_install("""-f https://download.pytorch.org/whl/torch_stable.html
--f https://raw.githubusercontent.com/agisoft-llc/metashape-scripts/master/misc/links.txt
+import urllib, tempfile
+temporary_file = tempfile.NamedTemporaryFile(delete=False)
+find_links_file_url = "https://raw.githubusercontent.com/agisoft-llc/metashape-scripts/master/misc/links.txt"
+urllib.request.urlretrieve(find_links_file_url, temporary_file.name)
+
+pip_install("""-f {find_links_file_path}
+-f https://download.pytorch.org/whl/torch_stable.html
 albumentations==1.0.3
 deepforest==1.2.4
 pytorch-lightning==1.5.10
 torch==1.9.0+cu111
 torchvision==0.10.0+cu111
-torchaudio===0.9.0""")
+torchaudio===0.9.0""".format(find_links_file_path=temporary_file.name.replace("\\", "\\\\")))
 
 def pandas_append(df, row, ignore_index=False):
     import pandas as pd

--- a/src/export_depth_maps_dialog.py
+++ b/src/export_depth_maps_dialog.py
@@ -4,13 +4,9 @@
 
 import Metashape
 from PySide2 import QtGui, QtCore, QtWidgets
+from modules.pip_auto_install import pip_install
 
-try:
-    import numpy as np
-except ImportError:
-    print("Please ensure that you installed numpy via 'pip install numpy' - see https://agisoft.freshdesk.com/support/solutions/articles/31000136860-how-to-install-external-python-module-to-metashape-professional-package")
-    raise
-
+pip_install("numpy")
 
 class ExportDepthDlg(QtWidgets.QDialog):
 

--- a/src/footprints_to_shapes.py
+++ b/src/footprints_to_shapes.py
@@ -7,7 +7,7 @@ import multiprocessing
 import concurrent.futures
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))
@@ -36,8 +36,8 @@ def create_footprints():
 
     if chunk.model:
         surface = chunk.model
-    elif chunk.dense_cloud:
-        surface = chunk.dense_cloud
+    elif chunk.point_cloud:
+        surface = chunk.point_cloud
     else:
         surface = chunk.point_cloud
 

--- a/src/import_depth.py
+++ b/src/import_depth.py
@@ -12,7 +12,7 @@ import os
 from pathlib import Path
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))
@@ -36,7 +36,7 @@ def import_external_depth():
 
     print("Saving preprocessed images to " + str(preprocessed_directory))
 
-    Metashape.app.document.chunk.importLaserScans(filenames = depth_images, color_filenames = color_images, image_path = str(preprocessed_directory) + "/{filename}.tif")
+    Metashape.app.document.chunk.importDepthImages(filenames = depth_images, color_filenames = color_images, image_path = str(preprocessed_directory) + "/{filename}.tif")
 
 label = "Scripts/Import external depth"
 Metashape.app.addMenuItem(label, import_external_depth)

--- a/src/masking_by_color_dialog.py
+++ b/src/masking_by_color_dialog.py
@@ -7,7 +7,7 @@ import tempfile, pathlib
 from PySide2 import QtGui, QtCore, QtWidgets
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/quick_layout.py
+++ b/src/quick_layout.py
@@ -6,7 +6,7 @@ import Metashape as ps
 import math, time
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(ps.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/read_altitude_from_DJI_meta.py
+++ b/src/read_altitude_from_DJI_meta.py
@@ -6,7 +6,7 @@
 import Metashape
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))
@@ -25,7 +25,9 @@ def read_DJI_relative_altitude():
     chunk = doc.chunk
 
     for camera in chunk.cameras:
-        if not camera.reference.location:
+        if not camera.type == Metashape.Camera.Type.Regular: #skip camera track, if any
+            continue
+        if (not camera.reference.location):
             continue
         if ("DJI/RelativeAltitude" in camera.photo.meta.keys()) and camera.reference.location:
             z = float(camera.photo.meta["DJI/RelativeAltitude"])

--- a/src/region_control.py
+++ b/src/region_control.py
@@ -11,7 +11,7 @@ from PySide2 import QtGui, QtCore, QtWidgets
 from PySide2.QtWidgets import *
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/render_photos_for_cameras.py
+++ b/src/render_photos_for_cameras.py
@@ -7,7 +7,7 @@ import Metashape
 import os
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))
@@ -30,6 +30,9 @@ def render_cameras():
         raise Exception("No model!")
 
     for camera in get_cameras(chunk):
+        if not camera.type == Metashape.Camera.Type.Regular: #skip camera track, if any
+            continue
+
         render = chunk.model.renderImage(camera.transform, camera.sensor.calibration)
 
         photo_dir = os.path.dirname(camera.photo.path)

--- a/src/render_spherical_panorama.py
+++ b/src/render_spherical_panorama.py
@@ -8,7 +8,7 @@ view_consistent_direction = False
 result_height_px = 4000
 
 # Checking compatibility
-preferred_major_version = "1.8"
+preferred_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != preferred_major_version:
     print("Unsupported Metashape version: {} != {}. Script may not work properly".format(found_major_version, preferred_major_version))

--- a/src/samples/general_workflow.py
+++ b/src/samples/general_workflow.py
@@ -2,7 +2,7 @@ import Metashape
 import os, sys, time
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))
@@ -50,10 +50,10 @@ doc.save()
 has_transform = chunk.transform.scale and chunk.transform.rotation and chunk.transform.translation
 
 if has_transform:
-    chunk.buildDenseCloud()
+    chunk.buildPointCloud()
     doc.save()
 
-    chunk.buildDem(source_data=Metashape.DenseCloudData)
+    chunk.buildDem(source_data=Metashape.PointCloudData)
     doc.save()
 
     chunk.buildOrthomosaic(surface_data=Metashape.ElevationData)
@@ -65,8 +65,8 @@ chunk.exportReport(output_folder + '/report.pdf')
 if chunk.model:
     chunk.exportModel(output_folder + '/model.obj')
 
-if chunk.dense_cloud:
-    chunk.exportPoints(output_folder + '/dense_cloud.las', source_data = Metashape.DenseCloudData)
+if chunk.point_cloud:
+    chunk.exportPointCloud(output_folder + '/point_cloud.las', source_data = Metashape.PointCloudData)
 
 if chunk.elevation:
     chunk.exportRaster(output_folder + '/dem.tif', source_data = Metashape.ElevationData)

--- a/src/samples/network_processing.py
+++ b/src/samples/network_processing.py
@@ -2,7 +2,7 @@ import Metashape
 import os, sys, time
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))
@@ -71,11 +71,11 @@ task.ghosting_filter = True
 tasks.append(task)
 
 if has_reference:
-    task = Metashape.Tasks.BuildDenseCloud()
+    task = Metashape.Tasks.BuildPointCloud()
     tasks.append(task)
 
     task = Metashape.Tasks.BuildDem()
-    task.source_data = Metashape.DenseCloudData
+    task.source_data = Metashape.PointCloudData
     tasks.append(task)
 
     task = Metashape.Tasks.BuildOrthomosaic()
@@ -90,9 +90,9 @@ task = Metashape.Tasks.ExportModel()
 task.path = output_folder + '/model.obj'
 tasks.append(task)
 
-task = Metashape.Tasks.ExportPoints()
-task.path = output_folder + '/dense_cloud.las'
-task.source_data = Metashape.DenseCloudData
+task = Metashape.Tasks.ExportPointCloud()
+task.path = output_folder + '/point_cloud.las'
+task.source_data = Metashape.PointCloudData
 tasks.append(task)
 
 if has_reference:

--- a/src/save_estimated_reference.py
+++ b/src/save_estimated_reference.py
@@ -6,7 +6,7 @@ import Metashape
 import math
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/split_calibration_by_order.py
+++ b/src/split_calibration_by_order.py
@@ -6,7 +6,7 @@
 import Metashape
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))
@@ -17,6 +17,9 @@ def split_cameras_calibration_group_by_order():
 
     chunk = Metashape.app.document.chunk 
     for camera in chunk.cameras:
+        if not camera.type == Metashape.Camera.Type.Regular: #skip camera track, if any
+            continue
+
         sensor = camera.sensor
         new_sensor = chunk.addSensor()
 

--- a/src/transfer_orientation.py
+++ b/src/transfer_orientation.py
@@ -14,10 +14,11 @@
 #
 
 import Metashape
+import datetime as dt
 from datetime import datetime, timedelta
 
 # Checking compatibility
-compatible_major_version = "1.8"
+compatible_major_version = "2.0"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))
@@ -54,7 +55,7 @@ def parse_datetime(time):
     try:
         return datetime.strptime(time, "%Y:%m:%d %H:%M:%S")
     except:
-        return datetime(datetime.MINYEAR, 1, 1)
+        return datetime(dt.MINYEAR, 1, 1)
 
 
 def get_camera_meta(cam):
@@ -126,7 +127,7 @@ def find_correspondence(cams_0, cams_1):
 def transfer_orientations():
     chunk = Metashape.app.document.chunk
 
-    enabled_cameras = list(filter(lambda c: c.enabled, chunk.cameras))
+    enabled_cameras = list(filter(lambda c: ((c.type == Metashape.Camera.Type.Regular) and c.enabled), chunk.cameras))
     master_cameras = list(filter(check_camera_master, enabled_cameras))
 
     cameras_estimated = list(filter(check_camera_transform, master_cameras))


### PR DESCRIPTION
"""
Metashape Image quality estimator Script (v 1.0)
Persa Koutsouradi, Feb 2023
Usage:
Workflow -> Batch Process -> Add -> Run script
This script estimates the quality of the images in a chunk.
When the image quality is less than 0.7, the image is removed form the chunk.

"""

import Metashape

# Checking compatibility
compatible_major_version = "1.8"
found_major_version = ".".join(Metashape.app.version.split('.')[:2])
if found_major_version != compatible_major_version:
    raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))


doc = Metashape.app.document
chunk = doc.chunk

quality_list = []

for camera in chunk.cameras:
    chunk.analyzePhotos(camera)
    if 'Image/Quality' in camera.meta:
        quality = float(camera.meta['Image/Quality'])
        if quality < 0.7:
            chunk.remove(camera)
        else:
            quality_list.append([camera.label, quality])

# Print the quality values for verification
print("Image quality values:")
print(quality_list)

