### PR TITLE
Update scripts for Metashape 2.1 version

### DIFF
--- a/src/add_altitude_to_reference.py
+++ b/src/add_altitude_to_reference.py
@@ -5,7 +5,7 @@
 import Metashape
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/automatic_masking.py
+++ b/src/automatic_masking.py
@@ -25,7 +25,7 @@ import concurrent.futures
 from modules.pip_auto_install import pip_install
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/bounding_box_to_coordinate_system.py
+++ b/src/bounding_box_to_coordinate_system.py
@@ -6,7 +6,7 @@ import Metashape
 import math
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/colorize_model_by_altitude.py
+++ b/src/colorize_model_by_altitude.py
@@ -7,7 +7,7 @@
 import Metashape
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/colorize_model_by_overlap.py
+++ b/src/colorize_model_by_overlap.py
@@ -9,7 +9,7 @@ import Metashape
 import time
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/contrib/apply_offset_to_cameras.py
+++ b/src/contrib/apply_offset_to_cameras.py
@@ -22,7 +22,7 @@ import Metashape
 print("Script started...")
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(

--- a/src/contrib/change_chunk_names.py
+++ b/src/contrib/change_chunk_names.py
@@ -12,7 +12,7 @@ ex) image name: "M33333_human_CR_000" -> chunk name: "M33333_human_CR"
 
 """
 
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/contrib/disable_models.py
+++ b/src/contrib/disable_models.py
@@ -10,7 +10,7 @@ This scrip disable current model of chunks.
 It is useful when you want to make models different quality in one batch process.
 """
 
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/contrib/gradual_selection_mesh.py
+++ b/src/contrib/gradual_selection_mesh.py
@@ -11,7 +11,7 @@ This script scans the number of components in a model and reduceing them continu
 I wanted to make "grasdual selection" tool, but this is slower than that.
 """
 
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/contrib/remove_disabled_photos.py
+++ b/src/contrib/remove_disabled_photos.py
@@ -15,7 +15,7 @@ When using, it is advisable to monitor the Console (View -> Console).
 
 """
 
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/contrib/remove_duplicated_photos.py
+++ b/src/contrib/remove_duplicated_photos.py
@@ -8,7 +8,7 @@ Matjaz Mori, CPA, May 2022
 The script will remove all duplicated photos (photos referenced to the same file) from Metashape project. 
 """
 
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/contrib/save_chunks.py
+++ b/src/contrib/save_chunks.py
@@ -10,7 +10,7 @@ This script saves each chunks separately.
 
 """
 
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/coordinate_system_to_bounding_box.py
+++ b/src/coordinate_system_to_bounding_box.py
@@ -6,7 +6,7 @@ import Metashape
 import math
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/copy_bounding_box_dialog.py
+++ b/src/copy_bounding_box_dialog.py
@@ -6,7 +6,7 @@ import Metashape
 from PySide2 import QtGui, QtCore, QtWidgets
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -68,7 +68,7 @@ import urllib.request, tempfile
 from modules.pip_auto_install import pip_install
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/export_for_gaussian_splatting.py
+++ b/src/export_for_gaussian_splatting.py
@@ -52,7 +52,7 @@ import math
 from PySide2 import QtGui, QtCore, QtWidgets
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/import_depth.py
+++ b/src/import_depth.py
@@ -12,7 +12,7 @@ import os
 from pathlib import Path
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/masking_by_color_dialog.py
+++ b/src/masking_by_color_dialog.py
@@ -7,7 +7,7 @@ import tempfile, pathlib
 from PySide2 import QtGui, QtCore, QtWidgets
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/quick_layout.py
+++ b/src/quick_layout.py
@@ -6,7 +6,7 @@ import Metashape as ps
 import math, time
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(ps.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/read_altitude_from_DJI_meta.py
+++ b/src/read_altitude_from_DJI_meta.py
@@ -6,7 +6,7 @@
 import Metashape
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/region_control.py
+++ b/src/region_control.py
@@ -11,7 +11,7 @@ from PySide2 import QtGui, QtCore, QtWidgets
 from PySide2.QtWidgets import *
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/remove_assets.py
+++ b/src/remove_assets.py
@@ -8,7 +8,7 @@ from PySide2 import QtGui, QtCore, QtWidgets
 import Metashape
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/render_photos_for_cameras.py
+++ b/src/render_photos_for_cameras.py
@@ -7,7 +7,7 @@ import Metashape
 import os
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/render_spherical_panorama.py
+++ b/src/render_spherical_panorama.py
@@ -3,15 +3,16 @@
 # This is python script for Metashape Pro. Scripts repository: https://github.com/agisoft-llc/metashape-scripts
 
 import math
+import Metashape
 
 view_consistent_direction = False
 result_height_px = 4000
 
 # Checking compatibility
-preferred_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
-if found_major_version != preferred_major_version:
-    print("Unsupported Metashape version: {} != {}. Script may not work properly".format(found_major_version, preferred_major_version))
+if found_major_version != compatible_major_version:
+    print("Unsupported Metashape version: {} != {}. Script may not work properly".format(found_major_version, compatible_major_version))
 
 def render_spherical_panorama(result_height_px, center, rotation, result_path):
     """

--- a/src/samples/general_workflow.py
+++ b/src/samples/general_workflow.py
@@ -2,7 +2,7 @@ import Metashape
 import os, sys, time
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/samples/laser_scans_workflow.py
+++ b/src/samples/laser_scans_workflow.py
@@ -18,16 +18,12 @@ import Metashape
 import os, sys
 
 # Checking compatibility
-compatible_major_version = "2.0"
-compatible_micro_version = 2
+compatible_major_version = "2.1"
 version_split = Metashape.app.version.split('.')
 found_major_version = ".".join(version_split[:2])
-found_micro_version = int(version_split[2])
 
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))
-if found_micro_version < compatible_micro_version:
-    raise Exception("Incompatible Metashape version: {}.{} < {}.{}".format(found_major_version, found_micro_version, compatible_major_version, compatible_micro_version))
 
 def find_files(folder, types):
     return [entry.path for entry in os.scandir(folder) if (entry.is_file() and os.path.splitext(entry.name)[1].lower() in types)]
@@ -98,7 +94,7 @@ doc.save()
 chunk.buildDepthMaps(downscale = 2, filter_mode = Metashape.MildFiltering)
 doc.save()
 
-chunk.buildModel(source_data = Metashape.DepthMapsData)
+chunk.buildModel(source_data = Metashape.DepthMapsAndLaserScansData)
 doc.save()
 
 if chunk.model:

--- a/src/samples/network_processing.py
+++ b/src/samples/network_processing.py
@@ -2,7 +2,7 @@ import Metashape
 import os, sys, time
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/save_estimated_reference.py
+++ b/src/save_estimated_reference.py
@@ -6,7 +6,7 @@ import Metashape
 import math
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/split_calibration_by_order.py
+++ b/src/split_calibration_by_order.py
@@ -6,7 +6,7 @@
 import Metashape
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/split_in_chunks_dialog.py
+++ b/src/split_in_chunks_dialog.py
@@ -5,7 +5,7 @@ import math
 from PySide2 import QtGui, QtCore, QtWidgets
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))

--- a/src/transfer_orientation.py
+++ b/src/transfer_orientation.py
@@ -18,7 +18,7 @@ import datetime as dt
 from datetime import datetime, timedelta
 
 # Checking compatibility
-compatible_major_version = "2.0"
+compatible_major_version = "2.1"
 found_major_version = ".".join(Metashape.app.version.split('.')[:2])
 if found_major_version != compatible_major_version:
     raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))


### PR DESCRIPTION
Changed laser scans workflow to use DepthMapsAndLaserScans data source
Updated footprints_to_shapes.py to support elevation as a base surface type.
Updated align_model_to_model.py to store transform in attribute matrix instead of changing vertices coordinates.
Updated compatible version of other scripts to 2.1