### PR TITLE
added menu item for tie points filtering, including cameras

### DIFF
--- a/src/contrib/filter_tie_points_region.py
+++ b/src/contrib/filter_tie_points_region.py
@@ -1,0 +1,132 @@
+import Metashape
+from PySide2 import QtWidgets
+
+# Checking compatibility
+compatible_major_version = "2.1"
+found_major_version = ".".join(Metashape.app.version.split('.')[:2])
+if found_major_version != compatible_major_version:
+    raise Exception("Incompatible Metashape version: {} != {}".format(found_major_version, compatible_major_version))
+
+class TiePointsRegionFilterDlg(QtWidgets.QDialog):
+
+    def __init__(self, parent):
+        QtWidgets.QDialog.__init__(self, parent)
+        self.setWindowTitle("Tie Points Region Filter Tool")
+
+        # Widgets
+        self.applyFilterButton = QtWidgets.QPushButton("Filter Tie Points")
+        self.closeButton = QtWidgets.QPushButton("Close")
+
+        self.infoLabel = QtWidgets.QLabel("Ensure tie points are selected in the 3D view before running.")
+        self.selectedPointsLabel = QtWidgets.QLabel(f"Selected Tie Points: {self.get_selected_tie_points_count()}")
+        self.removeCamerasCheckbox = QtWidgets.QCheckBox("Remove Disabled Cameras")
+
+        # Layout
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(self.infoLabel)
+        layout.addWidget(self.selectedPointsLabel)
+        layout.addWidget(self.removeCamerasCheckbox)
+        layout.addWidget(self.applyFilterButton)
+        layout.addWidget(self.closeButton)
+        self.setLayout(layout)
+
+        # Connect Actions
+        self.applyFilterButton.clicked.connect(self.filter_tie_points_region)
+        self.closeButton.clicked.connect(self.close)
+
+    def get_selected_tie_points_count(self):
+        """Return the number of selected tie points."""
+        doc = Metashape.app.document
+        chunk = doc.chunk
+
+        if not chunk or not chunk.tie_points:
+            return 0
+
+        return sum(1 for point in chunk.tie_points.points if point.selected)
+
+    def filter_tie_points_region(self):
+        """Filter tie points based on their inclusion in the region."""
+        doc = Metashape.app.document
+        chunk = doc.chunk
+
+        if not chunk or not chunk.tie_points:
+            QtWidgets.QMessageBox.warning(self, "Error", "No active chunk or tie points found.")
+            return
+
+        # Get the selected tie points
+        selected_points = [point for point in chunk.tie_points.points if point.selected]
+
+        if not selected_points:
+            QtWidgets.QMessageBox.warning(self, "Error", "No tie points selected.")
+            return
+
+        # Region parameters
+        region = chunk.region
+        R = region.rot
+        C = region.center
+        size = region.size
+
+        # Get selected point coordinates and calculate bounds in region space
+        min_coord = Metashape.Vector([float('inf')] * 3)
+        max_coord = Metashape.Vector([-float('inf')] * 3)
+
+        for point in selected_points:
+            coord = point.coord
+            coord.size = 3
+            v_c = coord - C
+            v_r = R.t() * v_c
+
+            min_coord = Metashape.Vector([min(min_coord[i], v_r[i]) for i in range(3)])
+            max_coord = Metashape.Vector([max(max_coord[i], v_r[i]) for i in range(3)])
+
+        # Update region
+        new_center = (min_coord + max_coord) / 2.0
+        new_size = max_coord - min_coord
+        region.center = C + R * new_center
+        region.size = new_size
+        chunk.region = region
+
+        # Filter tie points
+        valid_points = []
+        for point in chunk.tie_points.points:
+            if not point.valid:
+                continue
+
+            coord = point.coord
+            coord.size = 3
+            v_c = coord - region.center
+            v_r = R.t() * v_c
+
+            if (
+                -region.size.x / 2 <= v_r.x <= region.size.x / 2 and
+                -region.size.y / 2 <= v_r.y <= region.size.y / 2 and
+                -region.size.z / 2 <= v_r.z <= region.size.z / 2
+            ):
+                valid_points.append(point.track_id)
+            elif point not in selected_points:
+                point.valid = False
+
+        # Remove disabled cameras if checkbox is selected
+        if self.removeCamerasCheckbox.isChecked():
+            self.remove_disabled_cameras(chunk)
+
+        QtWidgets.QMessageBox.information(self, "Filter Complete",
+                                          f"Filtered {len(chunk.tie_points.points) - len(valid_points)} tie points.")
+
+    def remove_disabled_cameras(self, chunk):
+        """Removes all cameras in the chunk that are disabled."""
+        chunk.remove([camera for camera in chunk.cameras if not camera.enabled])
+
+def tie_points_region_filter_tool():
+    """Launch the Tie Points Region Filter Tool."""
+    app = QtWidgets.QApplication.instance()
+    parent = app.activeWindow()
+
+    dlg = TiePointsRegionFilterDlg(parent)
+    dlg.exec_()
+
+
+# Add script to Metashape menu
+label = "Scripts/Tie Points Region Filter Tool"
+Metashape.app.addMenuItem(label, tie_points_region_filter_tool)
+print(f"To execute this script, select {label}")


### PR DESCRIPTION
Summary:

This PR introduces a tool to filter tie points based on a selected region in the 3D view. It adjusts the bounding region dynamically and optionally removes cameras with no valid tie points.
How to Use:

    Select tie points in the 3D view that define your region of interest.
    Go to Scripts > Tie Points Region Filter Tool.
    Use the checkbox to toggle camera removal and click Filter Tie Points.

Key Features:

    Filters tie points based on selected region.
    Updates bounding region dynamically.
    Disables cameras outside the ROI.
    Optional camera removal.

![image](https://github.com/user-attachments/assets/3fed88cb-19fe-4ae1-9371-c1d2a005ce50)

Quick and simple.
Let me know if you need adjustments.